### PR TITLE
If the response returns an error that the request is cancelled, and t…

### DIFF
--- a/GirdersSwift/src/main/swift/promise/HTTPPromise.swift
+++ b/GirdersSwift/src/main/swift/promise/HTTPPromise.swift
@@ -1,6 +1,10 @@
 import Foundation
 import PromiseKit
 
+public enum ResponseStatusError: Error {
+    case Canceled
+}
+
 /// Extension of the standard HTTP with Promises.
 public extension HTTP {
     
@@ -10,7 +14,11 @@ public extension HTTP {
                            completionHandler: { (result: Result<Response<T>, Error?>) in
                 switch result {
                 case .Failure(let error):
-                    seal.reject(error!)
+                    if error!.isCancelled {
+                        seal.reject(ResponseStatusError.Canceled)
+                    } else {
+                        seal.reject(error!)
+                    }
                 case .Success(let data):
                     seal.fulfill(data)
                 }


### PR DESCRIPTION
…he promise is rejected with such an error, PromiseKit does not resolve the promise with calling the cathc block. In this commit I added a workaround, by rejecting the promise with a new cancelled response status error